### PR TITLE
Add optional `smooth` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Demo coming
 
 ## Installation
 
-Run `npm i react-scroll-to-top`
+Run `npm i react-scroll-to-top --save`
 
 ## Usage
 
@@ -29,13 +29,17 @@ function CoolPage() {
 
 ## Props
 
-| Prop      | Type   | Description                              | Default |
-| --------- | ------ | ---------------------------------------- | ------- |
-| top       | number | The height where the button gets visible | 20      |
-| color     | string | The arrow color                          | black   |
-| bgColor   | string | Button background color                  | white   |
-| className | string | Custom classname to add your own styling |         |
-| style     | Object | Object to override styling               |         |
+| Prop      | Type    | Description                              | Default |
+| --------- | ------- | ---------------------------------------- | ------- |
+| top       | number  | The height where the button gets visible | 20      |
+| color     | string  | The arrow color                          | black   |
+| bgColor   | string  | Button background color                  | white   |
+| className | string  | Custom classname to add your own styling | ''      |
+| style     | Object  | Object to override styling               |         |
+| smooth    | boolean | Whether to use smooth scrolling*         | false   |
+
+Smooth scrolling uses a newer `window.scrollTo` implementation.\
+[Check out its support in browsers at MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo).
 
 ## Types
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Demo coming
 
 ## Installation
 
-Run `npm i react-scroll-to-top --save`
+Run `npm i react-scroll-to-top`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scroll-to-top",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -488,6 +488,8 @@
     },
     "react": {
       "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-scroll-to-top",
   "author": "Herman Nygaard",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "main": "lib/ScrollToTop.js",
   "types": "lib/ScrollToTop.d.ts",
   "scripts": {

--- a/src/ScrollToTop.tsx
+++ b/src/ScrollToTop.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 
 type Props = {
   top?: number;
-  className?: string;
   color?: string;
   smooth?: boolean;
 };

--- a/src/ScrollToTop.tsx
+++ b/src/ScrollToTop.tsx
@@ -2,17 +2,27 @@ import React, { useState, useEffect } from "react";
 
 type Props = {
   top?: number;
+  className?: string;
   color?: string;
+  smooth?: boolean;
 };
 
-function scrollToTop() {
-  document.documentElement.scrollTop = 0;
+function scrollToTop(smooth: boolean = false) {
+  if (smooth) {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  } else {
+    document.documentElement.scrollTop = 0;
+  }
 }
 
 const ScrollToTop: React.FC<Props & React.HTMLAttributes<HTMLButtonElement>> = ({
   top = 20,
-  className,
+  className = "",
   color = "black",
+  smooth = false,
   ...props
 }) => {
   const [visible, setVisible] = useState(false);
@@ -29,7 +39,7 @@ const ScrollToTop: React.FC<Props & React.HTMLAttributes<HTMLButtonElement>> = (
   return (
     <>
       {visible && (
-        <button className={`${className} scroll-to-top`} onClick={scrollToTop} {...props}>
+        <button className={`${className} scroll-to-top`} onClick={() => scrollToTop(smooth)} {...props}>
           <svg fill={color} viewBox="0 0 256 256">
             <path d="M222.138,91.475l-89.6-89.6c-2.5-2.5-6.551-2.5-9.051,0l-89.6,89.6c-2.5,2.5-2.5,6.551,0,9.051s6.744,2.5,9.244,0L122,21.85  V249.6c0,3.535,2.466,6.4,6,6.4s6-2.865,6-6.4V21.85l78.881,78.676c1.25,1.25,2.992,1.875,4.629,1.875s3.326-0.625,4.576-1.875  C224.586,98.025,224.638,93.975,222.138,91.475z"></path>
           </svg>


### PR DESCRIPTION
Fixes #1 

This PR introduces a new `smooth` feature, which will scroll to top of the page using a smooth animation.

The feature is **opt-in and disabled by default**. Internally, it uses `window.scrollTo` handler. It has fairly good support in browsers, but is unfortunately not supported by Safari yet.

Tested locally on Chrome and Firefox (both latest).

**Implemented changes**
+ Added `--save` flag to npm installation instruction.
+ Updated props table within the README file to reflect the new prop and added an additional paragraph about the internal implementation.
+ Updated `type Props` to include the new `smooth` prop and aligned other props with the code.
+ Altered `scrollToTop` function.
+ Altered `className` prop to have an empty string by default (otherwise it producess a class of `"undefined scroll-to-top"`).
+ Bumped version to `0.2.0`.